### PR TITLE
Fixes to run on Windows Platform

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,10 +4,12 @@ var log = require("log");
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-    Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
-    
-    Alloy.CFG.tabGroup = $.index;    
-    $.index.open();    
+	if(OS_IOS) {
+    	Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
+	}
+
+    Alloy.CFG.tabGroup = $.index;
+    $.index.open();
 })();
 
 function validateDocsInfo() {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,9 +4,9 @@ var log = require("log");
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-	if(OS_IOS) {
-    	Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
-	}
+    if (OS_IOS) {
+        Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
+    }
 
     Alloy.CFG.tabGroup = $.index;
     $.index.open();

--- a/app/styles/app.tss
+++ b/app/styles/app.tss
@@ -2,6 +2,10 @@
 	backgroundColor: "white"
 }
 
+"Window[platform=windows]": {
+	backgroundColor: "black"
+}
+
 "Window[platform=ios]": {
 	barColor: Alloy.CFG.styles.tintColor,
 	navTintColor: "white",

--- a/app/styles/controls/index.tss
+++ b/app/styles/controls/index.tss
@@ -2,6 +2,6 @@
     icon: "images/icons/controls.png"
 }
 
-"#listView": {
+"#listView[platform=ios]": {
     defaultItemTemplate: Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE
 }

--- a/app/styles/controls/views/index.tss
+++ b/app/styles/controls/views/index.tss
@@ -1,3 +1,3 @@
-"#listView": {
+"#listView[platform=ios]": {
 	defaultItemTemplate: Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE
 }


### PR DESCRIPTION
* Windows would throw  `Undefined is not an object (evaluating 'template.properties')` on launch due to the constant `Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE` not being implemented as it is iOS only. 
   * Should this be under Ti.UI.iOS? 
   * We also should probably handle that better in Windows

* Both Windows and Android were crashing due to the Ti.App.iOS.addEventListener call so wrap in if(OS_IOS)

* Set the backgroundColor for a Window to black on Windows

**To verify**

1. Build the app for Android, it should launch without any errors
2. Build the app for Windows, it should launch  without any errors and the text for the different items should be visible.