### PR TITLE
[TIMOB-24274] Running KitchenSink v2 Windows ends up error

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,7 +4,9 @@ var log = require("log");
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-    Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
+    if (Ti.App.iOS) {
+        Ti.App.iOS.addEventListener('shortcutitemclick', handleShortcutItem);
+    }
     
     Alloy.CFG.tabGroup = $.index;    
     $.index.open();    

--- a/app/styles/controls/index.tss
+++ b/app/styles/controls/index.tss
@@ -5,3 +5,7 @@
 "#listView": {
     defaultItemTemplate: Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE
 }
+
+"#listView[platform=windows]": {
+    defaultItemTemplate: Ti.UI.LIST_ITEM_TEMPLATE_DEFAULT
+}


### PR DESCRIPTION
[TIMOB-24274](https://jira.appcelerator.org/browse/TIMOB-24274)

Running KitchenSink v2 Windows ends up error screen. This is because there's iOS-only API used (`Ti.App.iOS.addEventListener`), and also there's no support for `Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE` for Windows. We have coloring issue remains (for instance label looks hidden because default Windows label color is white & KitchenSink draws Window background color white) but this PR makes it launch with no errors at least. 