### PR TITLE
Windows stuff and cleanup

### DIFF
--- a/app/controllers/controls/commandbar.js
+++ b/app/controllers/controls/commandbar.js
@@ -1,0 +1,18 @@
+var log = require('log');
+
+/**
+ * The scoped constructor of the controller.
+ **/
+(function constructor() {
+
+})();
+
+function sayDelete(e) {
+	alert('Hey you just deleted something!')
+}
+
+function sayThanks(e) {
+	if (e.checked) {
+		alert('Thanks for liking!')
+	}
+}

--- a/app/controllers/controls/views/webview.js
+++ b/app/controllers/controls/views/webview.js
@@ -4,13 +4,21 @@ var log = require('log');
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-    
+
 })();
 
 function onBeforeLoad(e) {
-    log.args('Ti.UI.WebView will start loading content', e);
+    if(!OS_WINDOWS) {
+        log.args('Ti.UI.WebView will start loading content', e);
+    } else {
+        log.args('Ti.UI.WebView will start loading content');
+    }
 }
 
 function onLoad(e) {
-    log.args('Ti.UI.WebView completed loading content', e);
+    if(!OS_WINDOWS) {
+        log.args('Ti.UI.WebView completed loading content', e);
+    } else {
+        log.args('Ti.UI.WebView completed loading content');
+    }
 }

--- a/app/controllers/phone/cameraGallery.js
+++ b/app/controllers/phone/cameraGallery.js
@@ -4,12 +4,12 @@ var log = require('log');
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-    
+
 })();
 
 function openComponent(e) {
   var action = e.itemId
-  
+
   switch (action) {
     case 'showCameraPhoto': showCamera([Ti.Media.MEDIA_TYPE_PHOTO]);
     break
@@ -23,7 +23,7 @@ function openComponent(e) {
     break
     default: log.args('Ti.Media', 'Unknown action selected: ' + action);
   }
-  
+
   if (OS_IOS) {
       e.source.deselectItem(e.sectionIndex, e.itemIndex);
   }
@@ -52,25 +52,25 @@ function processImage(image) {
     image: image,
     opacity: 0
   });
-  
+
   var label = Ti.UI.createLabel({
     text: 'Tap to close'
   });
-  
-  image.addEventListener('click', function(e) {
-    image.animate({
+
+  imageView.addEventListener('click', function(e) {
+    imageView.animate({
       opacity: 0
     }, function() {
-      $.window.remove(image);
+      $.window.remove(imageView);
     })
   });
-  
+
   if (OS_IOS) {
-      image.add(label);
+      imageView.add(label);
   }
-  $.window.add(image);
-  
-  image.animate({
+  $.window.add(imageView);
+
+  imageView.animate({
     opacity: 1
   });
 }
@@ -83,7 +83,7 @@ function saveToGallery() {
     height: 400,
     borderRadius: 200
   });
-  
+
   // Convert the view to an image-blog and save it to your Gallery
   Ti.Media.saveToPhotoGallery(view.toImage(), {
     success: function(e) {

--- a/app/controllers/phone/cameraGallery.js
+++ b/app/controllers/phone/cameraGallery.js
@@ -1,112 +1,119 @@
 var log = require('log');
 
 /**
- * The scoped constructor of the controller.
- **/
+* The scoped constructor of the controller.
+**/
 (function constructor() {
 
 })();
 
 function openComponent(e) {
-  var action = e.itemId;
+    var action = e.itemId
 
-  switch (action) {
-    case 'showCameraPhoto': showCamera([Ti.Media.MEDIA_TYPE_PHOTO]);
-    break;
-    case 'showCameraVideo': showCamera([Ti.Media.MEDIA_TYPE_VIDEO]);
-    break;
-    case 'showCameraPhotoVideo': showCamera([Ti.Media.MEDIA_TYPE_PHOTO, Ti.Media.MEDIA_TYPE_VIDEO]);
-    break;
-    case 'saveToGallery': saveToGallery();
-    break;
-    case 'openFromGallery': openFromGallery();
-    break;
-    default: log.args('Ti.Media', 'Unknown action selected: ' + action);
-  }
+    switch (action) {
+        case 'showCameraPhoto':
+            showCamera([Ti.Media.MEDIA_TYPE_PHOTO]);
+            break;
+        case 'showCameraVideo':
+            showCamera([Ti.Media.MEDIA_TYPE_VIDEO]);
+            break;
+        case 'showCameraPhotoVideo':
+            showCamera([Ti.Media.MEDIA_TYPE_PHOTO, Ti.Media.MEDIA_TYPE_VIDEO]);
+            break;
+        case 'saveToGallery':
+            saveToGallery();
+            break;
+        case 'openFromGallery':
+            openFromGallery();
+            break
+        default:
+            log.args('Ti.Media', 'Unknown action selected: ' + action);
+            break;
+    }
 
-  if (OS_IOS) {
-      e.source.deselectItem(e.sectionIndex, e.itemIndex);
-  }
+    if (OS_IOS) {
+        e.source.deselectItem(e.sectionIndex, e.itemIndex);
+    }
 }
 
 function showCamera(mediaTypes) {
-  require("/permissions").checkCameraPermission(function() {
-      Ti.Media.showCamera({
-        mediaTypes: mediaTypes,
-        success: function(e) {
-          log.args('Ti.Media', 'Image taken successfully!');
-          processImage(e.media);
-        },
-        error: function(e) {
-          log.args('Ti.Media', 'Error showing camera: ' + e.error);
-        },
-        cancel: function(e) {
-          log.args('Ti.Media', 'Camera was cancelled');
-        }
+    require("/permissions").checkCameraPermission(function() {
+        Ti.Media.showCamera({
+            mediaTypes: mediaTypes,
+            success: function(e) {
+                log.args('Ti.Media', 'Image taken successfully!');
+                processImage(e.media)
+            },
+            error: function(e) {
+                log.args('Ti.Media', 'Error showing camera: ' + e.error);
+            },
+            cancel: function(e) {
+                log.args('Ti.Media', 'Camera was cancelled');
+            }
+        });
     });
-  });
 }
 
 function processImage(image) {
-  var imageView = Ti.UI.createImageView({
-    image: image,
-    opacity: 0
-  });
+    var imageView = Ti.UI.createImageView({
+        image: image,
+        opacity: 0
+    });
 
-  var label = Ti.UI.createLabel({
-    text: 'Tap to close'
-  });
+    var label = Ti.UI.createLabel({
+        text: 'Tap to close'
+    });
 
-  imageView.addEventListener('click', function(e) {
+    imageView.addEventListener('click', function(e) {
+        imageView.animate({
+            opacity: 0
+        }, function() {
+            $.window.remove(imageView);
+        });
+    });
+
+    if (OS_IOS) {
+        imageView.add(label);
+    }
+    $.window.add(imageView);
+
     imageView.animate({
-      opacity: 0
-    }, function() {
-      $.window.remove(imageView);
-  });
-
-  if (OS_IOS) {
-      imageView.add(label);
-  }
-  $.window.add(imageView);
-
-  imageView.animate({
-    opacity: 1
-  });
+        opacity: 1
+    });
 }
 
 function saveToGallery() {
-  // Create a 400x400px rounded square
-  var view = Ti.UI.createView({
-    backgroundColor: 'red',
-    width: 400,
-    height: 400,
-    borderRadius: 200
-  });
+    var view = Ti.UI.createView({
+        backgroundColor: 'red',
+        width: 400,
+        height: 400,
+        borderRadius: 200
+    });
 
-  // Convert the view to an image-blog and save it to your Gallery
-  Ti.Media.saveToPhotoGallery(view.toImage(), {
-    success: function(e) {
-      log.args('Ti.Media', 'Image saved to photo-gallery successfully!');
-    },
-    error: function(e) {
-      log.args('Ti.Media', 'Error saving image to photo-gallery: ' + e.error);
-    }
-  });
+    // Convert the view to an image-blog and save it to your Gallery
+    Ti.Media.saveToPhotoGallery(view.toImage(), {
+        success: function(e) {
+            log.args('Ti.Media', 'Image saved to photo-gallery successfully!');
+        },
+        error: function(e) {
+            log.args('Ti.Media', 'Error saving image to photo-gallery: ' + e.error);
+        }
+    });
 }
 
 function openFromGallery() {
-  require("/permissions").checkCameraPermission(function() {
-      Ti.Media.openPhotoGallery({
-        success: function(e) {
-          log.args('Ti.Media', 'Image open successfully!');
-          processImage(e.media);
-        },
-        error: function(e) {
-          log.args('Ti.Media', 'Error opening image: ' + e.error);
-        },
-        cancel: function(e) {
-          log.args('Ti.Media', 'Opening photo-gallery was cancelled');
-        }
-      });
-  });
+    require("/permissions").checkCameraPermission(function() {
+        Ti.Media.openPhotoGallery({
+            success: function(e) {
+                log.args('Ti.Media', 'Image open successfully!');
+            processImage(e.media)
+            },
+            error: function(e) {
+                log.args('Ti.Media', 'Error opening image: ' + e.error);
+            },
+            cancel: function(e) {
+                log.args('Ti.Media', 'Opening photo-gallery was cancelled');
+            }
+        });
+    });
 }

--- a/app/controllers/phone/database.js
+++ b/app/controllers/phone/database.js
@@ -8,17 +8,22 @@ var log = require('log');
 })(arguments[0] || {});
 
 function intitializeDatabase(e) {
-	var db = Ti.Database.install('/databases/kitchensink.db','kitchensink');
+	console.log(Ti.Platform.osname)
+	if (Ti.Platform.osname === 'windows') {
+		var db = Ti.Database.install(Ti.Filesystem.resourcesDirectory,'databases/kitchensink.db','kitchensink');
+	} else {
+		var db = Ti.Database.install('/databases/kitchensink.db','kitchensink');
+	}
 	var db = Ti.Database.open('kitchensink');
 	var updateName = 'I was updated';
 	var updateId = 4;
-	
+
 	/**
 	 *	Create new table and flush contents for a fresh start.
 	 **/
 	db.execute('CREATE TABLE IF NOT EXISTS DATABASETEST  (ID INTEGER, NAME TEXT)');
 	db.execute('DELETE FROM DATABASETEST');
-	
+
 	/**
 	 *	Insert new data to the database
 	 **/
@@ -36,27 +41,27 @@ function intitializeDatabase(e) {
 	 **/
 	db.execute('UPDATE DATABASETEST SET NAME = ? WHERE ID = ?', updateName, updateId);
 	db.execute('UPDATE DATABASETEST SET NAME = "I was updated, too!" WHERE ID = 2');
-	
+
 	log.args('Ti.Database', 'UPDATED NAME TO "I was updated, too!"');
-	
+
 	/**
 	 *	Delete data from the database.
 	 **/
 	db.execute('DELETE FROM DATABASETEST WHERE ID = ?', 1);
-	
+
 	log.args('Ti.Database', 'DELETED FROM DATABASE (WHERE ID = 1)');
-	
+
 	/**
 	 *	Select (query) data from the database.
 	 **/
 	var rows = db.execute('SELECT * FROM DATABASETEST');
-	log.args('Ti.Database', 'ROW COUNT = ' + rows.getRowCount());
-	
+	log.args('Ti.Database', 'ROW COUNT = ' + rows.rowCount);
+
 	while (rows.isValidRow()) {
-		log.args('Ti.Database', ' - ID: ' + rows.field(0) + ' NAME: ' + rows.fieldByName('name') + ' COLUMN NAME ' + rows.fieldName(0));	
+		log.args('Ti.Database', ' - ID: ' + rows.field(0) + ' NAME: ' + rows.fieldByName('name') + ' COLUMN NAME ' + rows.fieldName(0));
 		rows.next();
 	}
-	
+
 	rows.close();
 	db.close(); // close db when you're done to save resources
 

--- a/app/controllers/phone/soundLocal.js
+++ b/app/controllers/phone/soundLocal.js
@@ -6,12 +6,14 @@ var log = require('log'),
  * The scoped constructor of the controller.
  **/
 (function constructor() {
-    Ti.Media.setAudioSessionCategory(Ti.Media.AUDIO_SESSION_CATEGORY_AMBIENT);
+    if (!OS_ANDROID) {
+        Ti.Media.setAudioSessionCategory(Ti.Media.AUDIO_SESSION_CATEGORY_AMBIENT);
+    }
 
     soundPlayer = Titanium.Media.createSound({
         url: 'sounds/cricket.wav'
     });
-    
+
     soundPlayer.addEventListener('complete', onPlaybackComplete);
     soundPlayer.addEventListener('resume', onPlaybackResume);
 })();
@@ -48,7 +50,7 @@ function setVolumeDown() {
     if (soundPlayer.getVolume() > 0.0) {
          // TODO: Too complicated for 1 line? :-)
         soundPlayer.setVolume(soundPlayer.getVolume() < 0.1 ? 0 : (soundPlayer.volume -= 0.1));
-        
+
         $.buttonVolumeDown.setTitle('Volume-- (' + Math.round(soundPlayer.getVolume() * 1000) / 1000 + ')');
         $.buttonVolumeUp.setTitle('Volume++');
     }
@@ -63,14 +65,14 @@ function onPlaybackComplete() {
     $.playbackProgress.setValue(0);
 }
 
-function onPlaybackResume() {    
+function onPlaybackResume() {
     log.args('Ti.Media.Sound', 'The sound player was resumed!');
 }
 
 function startInterval() {
     playbackInterval = setInterval(function() {
 		if (soundPlayer.isPlaying()) {
-			$.playbackProgress.setValue(soundPlayer.getTime());
+			$.playbackProgress.setValue(soundPlayer.getTime() * 1000);
             log.args('Ti.Media.Sound', 'Time: ' + soundPlayer.getTime());
 		}
 	}, 500);

--- a/app/controllers/phone/soundLocal.js
+++ b/app/controllers/phone/soundLocal.js
@@ -57,7 +57,7 @@ function setVolumeDown() {
 }
 
 function toggleLooping() {
-    soundPlayer.setLooping(!soundPlayer.getLooping());
+    soundPlayer.setLooping(!soundPlayer.looping);
     $.buttonLooping.setTitle('Looping (' + soundPlayer.isLooping() + ')');
 }
 

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -1,34 +1,38 @@
 exports.checkCameraPermission = function(clb) {
-	var hasCameraPermissions = Ti.Media.hasCameraPermissions();
+	if (OS_WINDOWS) {
+		return clb();
+	} else {
+		var hasCameraPermissions = Ti.Media.hasCameraPermissions();
 
-	if (hasCameraPermissions) {
-		clb();
-		return;
-	}
-
-	if (OS_IOS) {
-		var map = {};
-		map[Ti.Media.CAMERA_AUTHORIZATION_AUTHORIZED] = 'CAMERA_AUTHORIZATION_AUTHORIZED';
-		map[Ti.Media.CAMERA_AUTHORIZATION_DENIED] = 'CAMERA_AUTHORIZATION_DENIED';
-		map[Ti.Media.CAMERA_AUTHORIZATION_RESTRICTED] = 'CAMERA_AUTHORIZATION_RESTRICTED';
-		map[Ti.Media.CAMERA_AUTHORIZATION_NOT_DETERMINED] = 'CAMERA_AUTHORIZATION_NOT_DETERMINED';
-
-		var cameraAuthorizationStatus = Ti.Media.cameraAuthorizationStatus;
-		if (cameraAuthorizationStatus === Ti.Media.CAMERA_AUTHORIZATION_RESTRICTED) {
-			return;
-		} else if (cameraAuthorizationStatus === Ti.Media.CAMERA_AUTHORIZATION_DENIED) {
-			return;
-		}
-	}
-
-	Ti.Media.requestCameraPermissions(function(e) {
-		if (e.success) {
+		if (hasCameraPermissions) {
 			clb();
 			return;
-		} else if (OS_ANDROID) {
-			return;
-		} else {
-			return;
 		}
-	});
-};
+
+		if (OS_IOS) {
+			var map = {};
+			map[Ti.Media.CAMERA_AUTHORIZATION_AUTHORIZED] = 'CAMERA_AUTHORIZATION_AUTHORIZED';
+			map[Ti.Media.CAMERA_AUTHORIZATION_DENIED] = 'CAMERA_AUTHORIZATION_DENIED';
+			map[Ti.Media.CAMERA_AUTHORIZATION_RESTRICTED] = 'CAMERA_AUTHORIZATION_RESTRICTED';
+			map[Ti.Media.CAMERA_AUTHORIZATION_NOT_DETERMINED] = 'CAMERA_AUTHORIZATION_NOT_DETERMINED';
+
+			var cameraAuthorizationStatus = Ti.Media.cameraAuthorizationStatus;
+			if (cameraAuthorizationStatus === Ti.Media.CAMERA_AUTHORIZATION_RESTRICTED) {
+				return;
+			} else if (cameraAuthorizationStatus === Ti.Media.CAMERA_AUTHORIZATION_DENIED) {
+				return;
+			}
+		}
+
+		Ti.Media.requestCameraPermissions(function(e) {
+			if (e.success) {
+				clb();
+				return;
+			} else if (OS_ANDROID) {
+				return;
+			} else {
+				return;
+			}
+		});
+	}
+}

--- a/app/styles/app.tss
+++ b/app/styles/app.tss
@@ -2,10 +2,6 @@
 	backgroundColor: 'white'
 }
 
-'Window[platform=windows]': {
-	backgroundColor: 'black'
-}
-
 'Window[platform=ios]': {
 	barColor: Alloy.CFG.styles.tintColor,
 	navTintColor: 'white',
@@ -76,6 +72,10 @@
 
 'TextField[platform=android]': {
 	color:'#000'
+}
+
+'ListItem[platform=windows]': {
+	color: '#000'
 }
 
 'TextArea[platform=android]': {

--- a/app/styles/app.tss
+++ b/app/styles/app.tss
@@ -2,6 +2,11 @@
 	backgroundColor: 'white'
 }
 
+// Workaround before https://jira.appcelerator.org/browse/ALOY-1582 is merged/published
+'Window[platform=windows formFactor=handheld]': {
+	backgroundColor: 'black'
+}
+
 'Window[platform=ios]': {
 	barColor: Alloy.CFG.styles.tintColor,
 	navTintColor: 'white',
@@ -74,7 +79,8 @@
 	color:'#000'
 }
 
-'ListItem[platform=windows]': {
+// Workaround before https://jira.appcelerator.org/browse/ALOY-1582 is merged/published
+'ListItem[platform=windows formFactor=tablet]': {
 	color: '#000'
 }
 

--- a/app/views/console/index.xml
+++ b/app/views/console/index.xml
@@ -5,6 +5,11 @@
             <ScrollView id="scrollView">
                 <Label id="log" />
             </ScrollView>
+            <CommandBar platform="windows">
+                <Items>
+                    <AppBarButton icon="DELETE" onClick="clearLogs"></AppBarButton>
+                </Items>
+            </CommandBar>
         </Window>
     </Tab>
 </Alloy>

--- a/app/views/controls/alertdialog.xml
+++ b/app/views/controls/alertdialog.xml
@@ -5,7 +5,8 @@
             <ButtonNames>
                 <ButtonName>Confirm</ButtonName>
                 <ButtonName>Delete</ButtonName>
-                <ButtonName>Cancel</ButtonName>
+                <!--More than two buttons on an dialog causes an error on Windows Mobile-->
+                <ButtonName platform="!windows">Cancel</ButtonName>
             </ButtonNames>
         </AlertDialog>
     </Window>

--- a/app/views/controls/commandbar.xml
+++ b/app/views/controls/commandbar.xml
@@ -1,0 +1,10 @@
+<Alloy>
+    <Window title="Command Bar">
+        <CommandBar platform="windows">
+            <Items>
+                <AppBarButton icon="DELETE" onClick="sayDelete"></AppBarButton>
+                <AppBarToggleButton icon="LIKE" onClick="sayThanks"></AppBarToggleButton>
+            </Items>
+        </CommandBar>
+    </Window>
+</Alloy>

--- a/app/views/controls/index.xml
+++ b/app/views/controls/index.xml
@@ -6,7 +6,8 @@
                     <ListItem title="Views" itemId="views/index" />
                     <ListItem title="Label" itemId="label" />
                     <ListItem title="Tabbed Bar" itemId="tabbedbar" platform="ios" />
-                    <ListItem title="Toolbar" itemId="toolbar" />
+                    <ListItem title="Toolbar" itemId="toolbar" platform="android,ios"/>
+                    <ListItem title="Command Bar" itemId="commandbar" platform="windows"/>
                     <ListItem title="Switch" itemId="switchcontrol" />
                     <ListItem title="Stepper" itemId="stepper" platform="ios"/>
                     <ListItem title="Slider" itemId="slider" />

--- a/app/views/controls/optiondialog.xml
+++ b/app/views/controls/optiondialog.xml
@@ -5,7 +5,8 @@
             <Options>
                 <Option>Confirm</Option>
                 <Option>Delete</Option>
-                <Option>Cancel</Option>
+                <!--More than two buttons on an dialog causes an error on Windows Mobile-->
+                <Option platform="!windows">Cancel</Option>
             </Options>
         </OptionDialog>
     </Window>

--- a/app/views/controls/views/listview.xml
+++ b/app/views/controls/views/listview.xml
@@ -14,6 +14,7 @@
             </Templates>
 
             <ListSection headerTitle="System Item Templates">
+                <!--Windows title and image overlay each other https://jira.appcelerator.org/browse/TIMOB-25326-->
                 <ListItem title="Bananas" image="/images/icons/tab.png" />
                 <ListItem title="Apples" subtitle="Oranges" template="Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE" />
                 <ListItem title="Mangos" subtitle="Strawberries" template="Ti.UI.LIST_ITEM_TEMPLATE_SETTINGS" />

--- a/app/views/controls/views/listview.xml
+++ b/app/views/controls/views/listview.xml
@@ -1,10 +1,10 @@
 <Alloy>
     <Window title="List View">
         <ListView onItemclick="handleListViewClick">
-            
+
             <!-- Enable Pull-to-Refresh -->
-            <RefreshControl id="refresh" onRefreshstart="fetchData" />
-            
+            <RefreshControl id="refresh" onRefreshstart="fetchData" platform="android,ios"/>
+
             <!-- Add custom item templates -->
             <Templates>
                 <ItemTemplate name="MyCustomTemplate">
@@ -12,19 +12,19 @@
                     <Label bindId="detail" class="detailLabel" />
                 </ItemTemplate>
             </Templates>
-            
+
             <ListSection headerTitle="System Item Templates">
                 <ListItem title="Bananas" image="/images/icons/tab.png" />
                 <ListItem title="Apples" subtitle="Oranges" template="Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE" />
                 <ListItem title="Mangos" subtitle="Strawberries" template="Ti.UI.LIST_ITEM_TEMPLATE_SETTINGS" />
                 <ListItem title="Lemon" subtitle="Melone" template="Ti.UI.LIST_ITEM_TEMPLATE_CONTACTS" />
             </ListSection>
-            
+
             <ListSection headerTitle="Custom Item Templates">
                 <ListItem template="MyCustomTemplate" title:text="Nectarine" detail:text="3" />
                 <ListItem template="MyCustomTemplate" title:text="Pear" detail:text="7" detail:color="blue" />
             </ListSection>
-            
+
             <ListSection headerTitle="Accessory Types">
                 <ListItem title="No Accessory" accessoryType="Ti.UI.LIST_ACCESSORY_TYPE_NONE" />
                 <ListItem title="Detail Accessory" accessoryType="Ti.UI.LIST_ACCESSORY_TYPE_DETAIL" />

--- a/app/views/mashups/index.xml
+++ b/app/views/mashups/index.xml
@@ -4,7 +4,7 @@
             <ListView id="listView" onItemclick="openComponent">
                 <ListSection>
                     <ListItem title="Twitter" itemId="twitter" />
-                    <ListItem title="Facebook" itemId="facebook" />
+                    <ListItem title="Facebook" itemId="facebook" platform="android,ios"/>
                 </ListSection>
             </ListView>
         </Window>

--- a/app/views/phone/cameraGallery.xml
+++ b/app/views/phone/cameraGallery.xml
@@ -7,7 +7,8 @@
                   <ListItem title="Show Camera (Photo + Video)" itemId="showCameraPhotoVideo" />
               </ListSection>
               <ListSection headerTitle="Gallery">
-                  <ListItem title="Save to Gallery" itemId="saveToGallery" />
+                  <!-- Disable on Windows, TIMOB-25282, TIMOB-25281-->
+                  <ListItem title="Save to Gallery" itemId="saveToGallery" platform="!windows"/>
                   <ListItem title="Open from Gallery" itemId="openFromGallery" />
               </ListSection>
           </ListView>

--- a/app/views/phone/cameraGallery.xml
+++ b/app/views/phone/cameraGallery.xml
@@ -5,7 +5,6 @@
                   <ListItem title="Show Camera (Photo)" itemId="showCameraPhoto" />
                   <ListItem title="Show Camera (Video)" itemId="showCameraVideo" />
                   <ListItem title="Show Camera (Photo + Video)" itemId="showCameraPhotoVideo" />
-                  <ListItem title="Show Camera (Photo + Video)" itemId="showCameraPhotoVideo" />
               </ListSection>
               <ListSection headerTitle="Gallery">
                   <ListItem title="Save to Gallery" itemId="saveToGallery" />

--- a/app/views/phone/soundLocal.xml
+++ b/app/views/phone/soundLocal.xml
@@ -6,8 +6,8 @@
             <Button onClick="resetPlayback" class="actionButton buttonReset" title="Reset" />
             <View class="horizontalContainer">
                 <Button onClick="setVolumeUp" class="actionButton buttonVolume" id="buttonVolumeUp" title="Volume++" />
-                <Button onClick="setVolumeDown" class="actionButton buttonVolume" id="buttonVolumeDown" title="Volume--" />                
-            </View>            
+                <Button onClick="setVolumeDown" class="actionButton buttonVolume" id="buttonVolumeDown" title="Volume--" />
+            </View>
             <Button onClick="toggleLooping" class="actionButton" id="buttonLooping" title="Looping (false)" />
         </View>
         <Toolbar platform="ios" class="playbackProgressToolbar">
@@ -17,6 +17,6 @@
                 <FlexSpace/>
             </Items>
         </Toolbar>
-        <ProgressBar platform="android" id="playbackProgress" />
+        <ProgressBar platform="android,windows" id="playbackProgress" />
     </Window>
 </Alloy>

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -85,17 +85,17 @@
             <uses-library android:name="com.google.android.maps" />
             <uses-sdk android:minSdkVersion="18" />
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
-            <application android:debuggable="true" 
+            <application android:debuggable="true"
                          android:hardwareAccelerated="true"
-                         android:largeHeap="true" 
+                         android:largeHeap="true"
                          android:theme="@style/kitchensink">
-                <meta-data android:name="com.google.android.maps.v2.API_KEY" 
+                <meta-data android:name="com.google.android.maps.v2.API_KEY"
                            android:value="[YOUR API KEY HERE]" />
                 <!--http://docs.appcelerator.com/platform/latest/#!/guide/Google_Maps_v2_for_Android-->
-                
-                <activity android:name="com.facebook.FacebookActivity" 
-                          android:theme="@android:style/Theme.Translucent.NoTitleBar" 
-                          android:label="KitchenSink" 
+
+                <activity android:name="com.facebook.FacebookActivity"
+                          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+                          android:label="KitchenSink"
                           android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation" />
                 <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
             </application>
@@ -117,5 +117,5 @@
         <module platform="android">facebook</module>
         <module platform="iphone">facebook</module>
     </modules>
-    <sdk-version>6.2.0.GA</sdk-version>
+    <sdk-version>6.2.1.GA</sdk-version>
 </ti:app>


### PR DESCRIPTION
- Adds example for command bar, add clearing logs with a command bar in console view, restrict toolbar to iOS and Android c9c5b492ba9c1173775e8883deffa42040343af6
- Fix some runtime errors on Windows around logging events and using image instead of imageView ca1cb294442258315a86bb853b9e893de2fbd71c
- Times soundPlayer.getTime() by 1000 like we do for max progress, style a little nicer on Windows, restrict RefreshControl to iOS and Android, remove dupe list entry 35efc70d0d255be98c34ee896e2916776923ce23