### PR TITLE
Add advanced gradient example

### DIFF
--- a/app/controllers/controls/views/gradients.js
+++ b/app/controllers/controls/views/gradients.js
@@ -21,7 +21,7 @@ var selectedGradient;
 
 function updateGradient() {
 	var size = $.gradientView.rect;
-	var minDimension = (size.width < size.height) ? size.width : size.height;
+	var minDimension = Math.min(size.width, size.height);
 	var centerPoint = {
 		x: size.width * normalizedCenterX,
 		y: size.height * normalizedCenterY,

--- a/app/controllers/controls/views/gradients.js
+++ b/app/controllers/controls/views/gradients.js
@@ -1,0 +1,110 @@
+var log = require('log');
+
+var normalizedCenterX;
+var normalizedCenterY;
+var colors;
+var Gradient;
+var gradientTypes;
+var selectedGradient;
+
+/**
+ * The scoped constructor of the controller.
+ **/
+(function constructor() {
+  normalizedCenterX = 0.5;
+  normalizedCenterY = 0.5;
+  colors = [ 'red', 'blue' ];
+  Gradient = { RADIAL: 0, LINEAR: 1 };
+  gradientTypes = [ 'radial', 'linear' ];
+  selectedGradient = Gradient.RADIAL;
+})();
+
+function updateGradient() {
+	var size = $.gradientView.rect;
+	var minDimension = (size.width < size.height) ? size.width : size.height;
+	var centerPoint = {
+		x: size.width * normalizedCenterX,
+		y: size.height * normalizedCenterY,
+	};
+	
+  var startRadius = (minDimension / 2) * ($.startRadiusSlider.value / 100);
+  var endRadius = (minDimension / 2) * ($.endRadiusSlider.value / 100);
+  
+  var gradient = {
+		type: gradientTypes[selectedGradient]
+	};
+  
+  // Linear gradients support colors with offsets and start-point / end-point
+  // Radial gradients support raw colors, start-radius / end-radius and backfill-start / backfill-end
+  // Read more: http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.View-property-backgroundGradient
+  if (selectedGradient == Gradient.LINEAR) {
+    var startPoint = { x: precisionRound($.startRadiusSlider.value , -1) + '%', y: '50%' };
+    var endPoint = { x: precisionRound($.endRadiusSlider.value, -1) + '%', y: '50%' };
+
+    gradient.colors = [{ color: colors[0], offset: 0.0 }, { color: colors[1], offset: 1.0 }];
+    gradient.startPoint = startPoint;
+    gradient.endPoint = endPoint;
+
+    log.args('Linear gradient updated: ' + JSON.stringify(centerPoint) + ', start-point: ' + JSON.stringify(startPoint) + ', end-point: ' + JSON.stringify(endPoint));
+  } else {
+    gradient.startPoint = centerPoint;
+    gradient.endPoint = centerPoint;
+    gradient.startRadius = startRadius;
+    gradient.endRadius = endRadius;
+    gradient.backfillStart = $.startFillSwitch.value;
+    gradient.backfillEnd = $.endFillSwitch.value;
+    gradient.colors = colors;
+
+    log.args('Radial gradient updated: ' + JSON.stringify(centerPoint) + ', start-radius: ' + startRadius + ', end-radius: ' + endRadius);
+  }
+  
+  $.gradientView.backgroundGradient = gradient;  
+}
+
+function handleTouchMove(e) {
+  var size = $.gradientView.rect;
+
+  if (OS_ANDROID && Ti.UI.defaultunit !== 'px') {
+    e.x /= Ti.Platform.displayCaps.logicalDensityFactor;
+    e.y /= Ti.Platform.displayCaps.logicalDensityFactor;
+  }
+
+  normalizedCenterX = (size.width > 0) ? (e.x / size.width) : 0.5;
+  normalizedCenterY = (size.height > 0) ? (e.y / size.height) : 0.5;
+
+  updateGradient();
+}
+
+function pickRandomColor() {
+  colors = [generateRandomColor(), generateRandomColor()];
+  updateGradient();
+}
+
+// CREDITS: https://stackoverflow.com/a/1484514/5537752
+function generateRandomColor() {
+  var letters = '0123456789ABCDEF';
+  var color = '#';
+
+  for (var i = 0; i < 6; i++) {
+    color += letters[Math.floor(Math.random() * 16)];
+  }
+
+  return color;
+}
+
+function handleGradientType(e) {
+  var isLinear = e.index == Gradient.LINEAR;
+  selectedGradient = e.index;
+  
+  $.startFillSwitch.enabled = !isLinear;
+  $.endFillSwitch.enabled = !isLinear;
+  $.startRadiusLabel.text = isLinear ? 'Start Point:' : 'Start Radius:'
+  $.endRadiusLabel.text = isLinear ? 'End Point' : 'End Radius';
+  
+  updateGradient();
+}
+
+function precisionRound(number, precision) {
+  var factor = Math.pow(10, precision);
+  return Math.round(number * factor) / factor;
+}

--- a/app/styles/controls/views/gradients.tss
+++ b/app/styles/controls/views/gradients.tss
@@ -1,0 +1,53 @@
+'Window': {
+	layout: 'vertical'
+}
+
+'#gradientView': {
+	backgroundColor: 'gray',
+	height: '50%',
+	width: Ti.UI.FILL
+}
+
+'.horizontalLayout': {
+	layout: 'horizontal'
+}
+
+'.radiusLabel': {
+	top: 20,
+	left: 10,
+}
+
+'.radiusSlider': {
+	min: 0,
+	max: 100,
+	value: 0,
+	top: 20,
+	left: 20,
+	right: 20,
+	width: Ti.UI.FILL
+}
+
+'.backfillLabel': {
+	top: 20,
+	left: 10
+}
+
+'.backfillSwitch': {
+	top: 20,
+	left: 10,
+	value: false
+}
+
+".colorPickerButton": {
+	top: 20,
+	left: 10,
+	width: Ti.UI.FILL,
+	textAlign: 'left'
+}
+
+'.gradientTypesBar': {
+	index: 0,
+	width: 200,
+	top: 20,
+	left: 10
+}

--- a/app/views/controls/views/gradients.xml
+++ b/app/views/controls/views/gradients.xml
@@ -1,0 +1,33 @@
+<Alloy>
+    <Window title="Gradients" onPostlayout="updateGradient">
+        <View id="gradientView" onTouchmove="handleTouchMove" />
+		<View class="horizontalLayout">
+			<!-- Start Radius -->
+			<Label class="radiusLabel" id="startRadiusLabel">Start Radius:</Label>
+			<Slider class="radiusSlider" id="startRadiusSlider" onChange="updateGradient" />
+
+			<!-- End Radius -->
+			<Label class="radiusLabel" id="endRadiusLabel">End Radius:</Label>
+			<Slider class="radiusSlider" id="endRadiusSlider" onChange="updateGradient" />
+			
+			<!-- Backfill Start -->
+			<Label class="backfillLabel">Back Fill Start:</Label>
+			<Switch class="backfillSwitch" id="startFillSwitch" onChange="updateGradient" />
+
+			<!-- Backfill End -->
+			<Label class="backfillLabel">Back Fill End:</Label>
+			<Switch class="backfillSwitch" id="endFillSwitch" onChange="updateGradient" />
+            
+            <!-- Random color -->
+            <Button onClick="pickRandomColor" class="colorPickerButton" title="🔄 Pick Random Color" />
+
+            <!-- Radial / linear -->
+            <TabbedBar class="gradientTypesBar" onClick="handleGradientType">
+                <Labels>
+                    <Label>Radial</Label>
+                    <Label>Linear</Label>
+                </Labels>
+            </TabbedBar>
+		</View>
+    </Window>
+</Alloy>

--- a/app/views/controls/views/index.xml
+++ b/app/views/controls/views/index.xml
@@ -2,13 +2,14 @@
     <Window title="Controls">
         <ListView id="listView" onItemclick="openComponent">
             <ListSection>
-                <ListItem title="View" subtitle="Ti.UI.View" itemId="view" />
-                <ListItem title="Scroll View" subtitle="Ti.UI.ScrollView" itemId="scrollview" />
-                <ListItem title="Scrollable View" subtitle="Ti.UI.ScrollableView" itemId="scrollableview" />
-                <ListItem title="List View" subtitle="Ti.UI.ListView" itemId="listview" />
-                <ListItem title="Blur View" subtitle="Ti.UI.BlurView" itemId="blurview" platform="ios"/>
-                <ListItem title="Image View" subtitle="Ti.UI.ImageView" itemId="imageview" />
-                <ListItem title="Web View" subtitle="Ti.UI.WebView" itemId="webview" />
+                <ListItem title="View" itemId="view" />
+                <ListItem title="Scroll View" itemId="scrollview" />
+                <ListItem title="Scrollable View" itemId="scrollableview" />
+                <ListItem title="List View" itemId="listview" />
+                <ListItem title="Blur View" itemId="blurview" platform="ios"/>
+                <ListItem title="Image View" itemId="imageview" />
+                <ListItem title="Web View" itemId="webview" />
+                <ListItem title="Gradients" itemId="gradients" />
             </ListSection>
         </ListView>
     </Window>

--- a/plugins/ti.alloy/hooks/alloy.js
+++ b/plugins/ti.alloy/hooks/alloy.js
@@ -152,10 +152,9 @@ exports.init = function (logger, config, cli, appc) {
 						cmd.map(function(a) {
 							if (/^[^"].* .*[^"]/.test(a)) return '"' + a + '"'; return a;
 						}).join(' ') + '"'].join(' ')], {
-							stdio: 'inherit',
-							windowsVerbatimArguments: true
-						}
-					);
+						stdio: 'inherit',
+						windowsVerbatimArguments: true
+					});
 				} else {
 					logger.info(__('Executing Alloy compile: %s', cmd.join(' ').cyan));
 					child = spawn(cmd.shift(), cmd);

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -115,6 +115,6 @@
     <module platform="android">facebook</module>
     <module platform="iphone">facebook</module>
   </modules>
-  <sdk-version>7.0.2.GA</sdk-version>
+  <sdk-version>7.1.0.GA</sdk-version>
   <property name="appc-app-id" type="string">5a8e9e2942e2dd6ef550ebdc</property>
 </ti:app>

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -1,125 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ti:app xmlns:ti="http://ti.appcelerator.org">
-    <id>com.appcelerator.kitchensink</id>
-    <name>KitchenSink</name>
-    <version>7.0.2</version>
-    <publisher>Appcelerator, Inc.</publisher>
-    <url>https://appcelerator.com</url>
-    <description/>
-    <copyright>Appcelerator, Inc.</copyright>
-    <icon>appicon.png</icon>
-    <fullscreen>false</fullscreen>
-    <navbar-hidden>false</navbar-hidden>
-    <analytics>true</analytics>
-    <guid>11111111-1111-1111-1111-111111111111</guid>
-    <property name="ti.ui.defaultunit" type="string">dp</property>
-    <property name="run-on-main-thread" type="bool">true</property>
-    <ios>
-        <enable-launch-screen-storyboard>true</enable-launch-screen-storyboard>
-        <default-background-color>#c91326</default-background-color>
-        <plist>
+<ti:app 
+  xmlns:ti="http://ti.appcelerator.org">
+  <id>com.appcelerator.kitchensink</id>
+  <name>KitchenSink</name>
+  <version>7.0.2</version>
+  <publisher>Appcelerator, Inc.</publisher>
+  <url>https://appcelerator.com</url>
+  <description/>
+  <copyright>Appcelerator, Inc.</copyright>
+  <icon>appicon.png</icon>
+  <fullscreen>false</fullscreen>
+  <navbar-hidden>false</navbar-hidden>
+  <analytics>true</analytics>
+  <guid>993f27fa-71ca-4192-9444-d6b3f1bab694</guid>
+  <property name="ti.ui.defaultunit" type="string">dp</property>
+  <property name="run-on-main-thread" type="bool">true</property>
+  <ios>
+    <enable-launch-screen-storyboard>true</enable-launch-screen-storyboard>
+    <default-background-color>#c91326</default-background-color>
+    <plist>
+      <dict>
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+          <string>fbapi</string>
+          <string>fb-messenger-api</string>
+          <string>fbauth2</string>
+          <string>fbshareextension</string>
+        </array>
+        <key>CFBundleURLTypes</key>
+        <array>
+          <dict>
+            <key>CFBundleURLName</key>
+            <!-- Application ID same as the id value in the tiapp.xml file -->
+            <string>[YOUR FACEBOOK ID]</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+              <!-- Prefix the Facebook App ID with 'fb' -->
+              <string>fb[YOUR FACEBOOK ID]</string>
+            </array>
+          </dict>
+        </array>
+        <!-- https://developers.facebook.com/ -->
+        <key>FacebookAppID</key>
+        <!-- Facebook App ID -->
+        <string>[YOUR FACEBOOK ID]</string>
+        <key>FacebookDisplayName</key>
+        <!-- Facebook App Name from developer.facebook.com -->
+        <string>KitchenSink</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>We need permission to look at your photo library.</string>
+        <key>NSLocationAlwaysUsageDescription</key>
+        <string>We need your location so we can cross check where you are so we can find you!</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>We need permission to access the microphone on your device for audio input or recording.</string>
+        <key>NSCameraUsageDescription</key>
+        <string>We need permission to access your device camera.</string>
+        <key>UIStatusBarStyle</key>
+        <string>UIStatusBarStyleLightContent</string>
+        <!-- Define static shortcuts here -->
+        <key>UIApplicationShortcutItems</key>
+        <array>
+          <!-- Each <dict> represents one shortcut item -->
+          <dict>
+            <!-- System-provided icon -->
+            <key>UIApplicationShortcutItemIconType</key>
+            <string>UIApplicationShortcutIconTypeAdd</string>
+            <!-- Title - Can be a name in an i18n/<lang>/app.xml file -->
+            <key>UIApplicationShortcutItemTitle</key>
+            <string>add_title</string>
+            <!-- Subtitle - Can be a name in an i18n/<lang>/app.xml file -->
+            <key>UIApplicationShortcutItemSubtitle</key>
+            <string>add_subtitle</string>
+            <!-- Type used to identify the action in the event listener -->
+            <key>UIApplicationShortcutItemType</key>
+            <string>add</string>
+            <!-- Custom dictionary (object) to receive in the event -->
+            <key>UIApplicationShortcutItemUserInfo</key>
             <dict>
-                <key>LSApplicationQueriesSchemes</key>
-                <array>
-                    <string>fbapi</string>
-                    <string>fb-messenger-api</string>
-                    <string>fbauth2</string>
-                    <string>fbshareextension</string>
-                </array>
-                <key>CFBundleURLTypes</key>
-                <array>
-                    <dict>
-                        <key>CFBundleURLName</key>
-                        <!-- Application ID same as the id value in the tiapp.xml file -->
-                        <string>[YOUR FACEBOOK ID]</string>
-                        <key>CFBundleURLSchemes</key>
-                        <array>
-                            <!-- Prefix the Facebook App ID with 'fb' -->
-                            <string>fb[YOUR FACEBOOK ID]</string>
-                        </array>
-                    </dict>
-                </array>
-                <!-- https://developers.facebook.com/ -->
-                <key>FacebookAppID</key>
-                <!-- Facebook App ID -->
-                <string>[YOUR FACEBOOK ID]</string>
-                <key>FacebookDisplayName</key>
-                <!-- Facebook App Name from developer.facebook.com -->
-                <string>KitchenSink</string>
-                <key>NSPhotoLibraryUsageDescription</key>
-                <string>We need permission to look at your photo library.</string>
-                <key>NSLocationAlwaysUsageDescription</key>
-                <string>We need your location so we can cross check where you are so we can find you!</string>
-                <key>NSMicrophoneUsageDescription</key>
-                <string>We need permission to access the microphone on your device for audio input or recording.</string>
-                <key>NSCameraUsageDescription</key>
-                <string>We need permission to access your device camera.</string>
-                <key>UIStatusBarStyle</key>
-                <string>UIStatusBarStyleLightContent</string>
-                <!-- Define static shortcuts here -->
-                <key>UIApplicationShortcutItems</key>
-                <array>
-                    <!-- Each <dict> represents one shortcut item -->
-                    <dict>
-                        <!-- System-provided icon -->
-                        <key>UIApplicationShortcutItemIconType</key>
-                        <string>UIApplicationShortcutIconTypeAdd</string>
-                        <!-- Title - Can be a name in an i18n/<lang>/app.xml file -->
-                        <key>UIApplicationShortcutItemTitle</key>
-                        <string>add_title</string>
-                        <!-- Subtitle - Can be a name in an i18n/<lang>/app.xml file -->
-                        <key>UIApplicationShortcutItemSubtitle</key>
-                        <string>add_subtitle</string>
-                        <!-- Type used to identify the action in the event listener -->
-                        <key>UIApplicationShortcutItemType</key>
-                        <string>add</string>
-                        <!-- Custom dictionary (object) to receive in the event -->
-                        <key>UIApplicationShortcutItemUserInfo</key>
-                        <dict>
-                            <key>myCustomKey</key>
-                            <string>myCustomValue</string>
-                        </dict>
-                    </dict>
-                </array>
+              <key>myCustomKey</key>
+              <string>myCustomValue</string>
             </dict>
-        </plist>
-    </ios>
-    <android xmlns:android="http://schemas.android.com/apk/res/android">
-        <manifest android:versionCode="2" android:versionName="2.1.0">
-            <uses-library android:name="com.google.android.maps" />
-            <uses-sdk android:minSdkVersion="18" />
-            <uses-permission android:name="android.permission.RECORD_AUDIO" />
-            <application android:debuggable="true"
-                         android:hardwareAccelerated="true"
-                         android:largeHeap="true"
-                         android:theme="@style/kitchensink">
-                <meta-data android:name="com.google.android.maps.v2.API_KEY"
-                           android:value="[YOUR API KEY HERE]" />
-                <!--http://docs.appcelerator.com/platform/latest/#!/guide/Google_Maps_v2_for_Android-->
-
-                <activity android:name="com.facebook.FacebookActivity"
-                          android:theme="@android:style/Theme.Translucent.NoTitleBar"
-                          android:label="KitchenSink"
-                          android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation" />
-                <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
-            </application>
-        </manifest>
-    </android>
-    <deployment-targets>
-        <target device="android">true</target>
-        <target device="ipad">true</target>
-        <target device="iphone">true</target>
-        <target device="mobileweb">false</target>
-        <target device="windows">false</target>
-    </deployment-targets>
-    <plugins>
-        <plugin version="1.0">ti.alloy</plugin>
-    </plugins>
-    <modules>
-        <module platform="iphone">ti.map</module>
-        <module platform="android">ti.map</module>
-        <module platform="android">facebook</module>
-        <module platform="iphone">facebook</module>
-    </modules>
-    <sdk-version>7.0.2.GA</sdk-version>
+          </dict>
+        </array>
+      </dict>
+    </plist>
+  </ios>
+  <android 
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <manifest android:versionCode="2" android:versionName="2.1.0">
+      <uses-library android:name="com.google.android.maps"/>
+      <uses-sdk android:minSdkVersion="18"/>
+      <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+      <application android:debuggable="true" android:hardwareAccelerated="true" android:largeHeap="true" android:theme="@style/kitchensink">
+        <meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="[YOUR API KEY HERE]"/>
+        <!--http://docs.appcelerator.com/platform/latest/#!/guide/Google_Maps_v2_for_Android-->
+        <activity android:name="com.facebook.FacebookActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:label="KitchenSink" android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"/>
+        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
+      </application>
+    </manifest>
+  </android>
+  <deployment-targets>
+    <target device="android">true</target>
+    <target device="ipad">true</target>
+    <target device="iphone">true</target>
+    <target device="mobileweb">false</target>
+    <target device="windows">false</target>
+  </deployment-targets>
+  <plugins>
+    <plugin version="1.0">ti.alloy</plugin>
+  </plugins>
+  <modules>
+    <module platform="iphone">ti.map</module>
+    <module platform="android">ti.map</module>
+    <module platform="android">facebook</module>
+    <module platform="iphone">facebook</module>
+  </modules>
+  <sdk-version>7.0.2.GA</sdk-version>
+  <property name="appc-app-id" type="string">5a8e9e2942e2dd6ef550ebdc</property>
 </ti:app>


### PR DESCRIPTION
Titanium SDK 7.1.0 brings more parity on gradients, adding `radial` gradients on Android. This example (thanks to @jquick-axway) represents an interactive way to configure gradients and all relevant properties are logged to the console on change, so they can be taken over to real projects afterwards.

<img src="https://user-images.githubusercontent.com/10667698/36537059-4c3f0e22-17cf-11e8-9304-452e3b1d0ce3.png" height="500" /> <img src="https://user-images.githubusercontent.com/10667698/36537060-4c58f788-17cf-11e8-99a3-1ade855619f5.png" height="500" />
