### PR TITLE
fix: add prefix to ios-only styles

### DIFF
--- a/app/styles/app.tss
+++ b/app/styles/app.tss
@@ -56,11 +56,11 @@
 	extendSafeArea: false
 }
 
-'.largeTitles': {
+'.largeTitles[platform=ios]': {
   largeTitleEnabled: true,
   largeTitleDisplayMode: Ti.UI.iOS.LARGE_TITLE_DISPLAY_MODE_ALWAYS
 }
 
-'.noLargeTitles': {
+'.noLargeTitles[platform=ios]': {
   largeTitleDisplayMode: Ti.UI.iOS.LARGE_TITLE_DISPLAY_MODE_NEVER
 }


### PR DESCRIPTION
crashed with
```
TypeError: Cannot read property 'LARGE_TITLE_DISPLAY_MODE_ALWAYS' of undefined
```
when running an Android app